### PR TITLE
feat: add logout functionality

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -21,18 +21,17 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Kevin Wang, Graham Williams
+/// Authors: Kevin Wang, Graham Williams, Ashley Tang
 
 library;
 
 import 'package:flutter/material.dart';
+import 'package:healthpod/utils/session_utils.dart'; 
 
 import 'package:healthpod/constants/colours.dart';
 import 'package:healthpod/widgets/icon_grid_page.dart';
 
 class HealthPodHome extends StatefulWidget {
-  /// Constructor for the home screen.
-
   const HealthPodHome({super.key});
 
   @override
@@ -52,6 +51,13 @@ class HealthPodHomeState extends State<HealthPodHome> {
         title: const Text('Your Health - Your Data - You Decide ... '),
         backgroundColor: titleBackgroundColor,
         automaticallyImplyLeading: false,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            tooltip: 'Logout',
+            onPressed: () => handleLogout(context), 
+          ),
+        ],
       ),
       backgroundColor: titleBackgroundColor,
       body: IconGridPage(),

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -26,7 +26,7 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:healthpod/utils/session_utils.dart'; 
+import 'package:healthpod/utils/session_utils.dart';
 
 import 'package:healthpod/constants/colours.dart';
 import 'package:healthpod/widgets/icon_grid_page.dart';
@@ -55,7 +55,7 @@ class HealthPodHomeState extends State<HealthPodHome> {
           IconButton(
             icon: const Icon(Icons.logout),
             tooltip: 'Logout',
-            onPressed: () => handleLogout(context), 
+            onPressed: () => handleLogout(context),
           ),
         ],
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,52 +21,27 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Graham Williams
+/// Authors: Graham Williams, Ashley Tang
 
 library;
 
 import 'package:flutter/material.dart';
-
-import 'package:solidpod/solidpod.dart';
 import 'package:window_manager/window_manager.dart';
-
 import 'package:healthpod/home.dart';
 import 'package:healthpod/utils/is_desktop.dart';
+import 'package:healthpod/utils/session_utils.dart'; 
+
+
 
 void main() async {
-  // This is the main entry point for the app. The [async] is required because
-  // we asynchronously [await] the window manager below. Often, `main()` will
-  // simply include just [runApp].
-
   if (isDesktop(PlatformWrapper())) {
-    // Suport [windowManager] options for the desktop. We do this here before
-    // running the app. If there is no [windowManager] options we probably don't
-    // need this whole section.
-
-    // Enusre things are set up properly since we haven't yet initialised the
-    // app with [runApp].
-
     WidgetsFlutterBinding.ensureInitialized();
-
     await windowManager.ensureInitialized();
 
     const windowOptions = WindowOptions(
-      // We can set various desktop window options here.
-
-      // Setting [alwaysOnTop] here will ensure the app starts on top of other
-      // apps on the desktop so that it is visible (otherwise, Ubuuntu with
-      // GNOME it is often lost below other windows on startup which can be a
-      // little disconcerting). We later turn it off as we don't want to force
-      // it always on top.
-
       alwaysOnTop: true,
-
-      // The [title] is used for the window manager's window title.
-
       title: 'HealthPod - Private Solid Pod for Storing Key-Value Pairs',
     );
-
-    // Once the window manager is ready we recofigure it a little.
 
     await windowManager.waitUntilReadyToShow(windowOptions, () async {
       await windowManager.show();
@@ -75,59 +50,19 @@ void main() async {
     });
   }
 
-  // Ready to run the app.
-
   runApp(const HealthPod());
 }
-
-// The main widget could be in a separate file, but handy having it in main and
-// the file is not too large. The widget essentially orchestrates the building
-// of other widgets. Generically we set up to build a `Home()` widget containing
-// the App. For SolidPod we wrap the `Home()` widget within the `SolidLogin()`
-// widget so we start with a login screen, though this is optional.
 
 class HealthPod extends StatelessWidget {
   const HealthPod({super.key});
 
-  // This StatelessWidget is the root of our application.
-
   @override
   Widget build(BuildContext context) {
+    checkAndRedirectLogin(context); // Use the utility function.
     return const MaterialApp(
       title: 'Solid Health Pod',
       home: SelectionArea(
-        // Wrap the whole app inside a SelectionArea to ensure we get selectable
-        // text, for text that can be selected, as a default.
-
-        child: SolidLogin(
-          // Wrap the actual home widget within a [SolidLogin].
-
-          // If the app has functionality that does not require access to Pod
-          // data then [required] can be `false`. If the user connects to their
-          // Pod then their session information will be saved to save having to
-          // log in everytime. The login token and the security key are (optionally)
-          // cached so that the login information is not required every time.
-          //
-          // In this demo app we allow the CONTINUE button so as to demonstrate
-          // the use of [SolidLoginPopup] during the app session. If we want to
-          // save the data to the Pod or view data from the Pod, then if the
-          // user did not log in during startup we can call [SolidLoginPopup] to
-          // establish the connection at that time.
-
-          required: false,
-
-          title: 'HEALTH POD',
-          image: AssetImage('assets/images/healthpod_image.png'),
-          logo: AssetImage('assets/images/healthpod_logo.png'),
-          link: 'https://github.com/anusii/healthpod/blob/main/README.md',
-          infoButtonStyle: InfoButtonStyle(
-            tooltip: 'Visit the HealthPod documentation.',
-          ),
-          loginButtonStyle: LoginButtonStyle(
-            background: Colors.lightGreenAccent,
-          ),
-          child: HealthPodHome(),
-        ),
+        child: HealthPodHome(),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,9 +29,7 @@ import 'package:flutter/material.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:healthpod/home.dart';
 import 'package:healthpod/utils/is_desktop.dart';
-import 'package:healthpod/utils/session_utils.dart'; 
-
-
+import 'package:healthpod/utils/session_utils.dart';
 
 void main() async {
   if (isDesktop(PlatformWrapper())) {

--- a/lib/utils/session_utils.dart
+++ b/lib/utils/session_utils.dart
@@ -4,7 +4,7 @@ import 'package:solidpod/solidpod.dart' show SolidLogin, getWebId, logoutPopup;
 
 /// Handles logout and navigates to the login screen
 Future<void> handleLogout(BuildContext context) async {
-  await logoutPopup(context, const HealthPodHome()); 
+  await logoutPopup(context, const HealthPodHome());
 
   // Check login status using getWebId
   final webId = await getWebId();
@@ -18,7 +18,7 @@ Future<void> handleLogout(BuildContext context) async {
           image: AssetImage('assets/images/healthpod_image.png'),
           logo: AssetImage('assets/images/healthpod_logo.png'),
           link: 'https://github.com/anusii/healthpod/blob/main/README.md',
-          child: HealthPodHome(), 
+          child: HealthPodHome(),
         ),
       ),
     );
@@ -44,7 +44,7 @@ Future<void> checkAndRedirectLogin(BuildContext context) async {
               image: AssetImage('assets/images/healthpod_image.png'),
               logo: AssetImage('assets/images/healthpod_logo.png'),
               link: 'https://github.com/anusii/healthpod/blob/main/README.md',
-              child: HealthPodHome(), 
+              child: HealthPodHome(),
             ),
           ),
         );

--- a/lib/utils/session_utils.dart
+++ b/lib/utils/session_utils.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:healthpod/home.dart';
+import 'package:solidpod/solidpod.dart' show SolidLogin, getWebId, logoutPopup;
+
+/// Handles logout and navigates to the login screen
+Future<void> handleLogout(BuildContext context) async {
+  await logoutPopup(context, const HealthPodHome()); 
+
+  // Check login status using getWebId
+  final webId = await getWebId();
+  if (webId == null && context.mounted) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const SolidLogin(
+          required: false,
+          title: 'HEALTH POD',
+          image: AssetImage('assets/images/healthpod_image.png'),
+          logo: AssetImage('assets/images/healthpod_logo.png'),
+          link: 'https://github.com/anusii/healthpod/blob/main/README.md',
+          child: HealthPodHome(), 
+        ),
+      ),
+    );
+  } else if (context.mounted) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Logout failed. Please try again.')),
+    );
+  }
+}
+
+/// Checks if the user is logged in and navigates appropriately
+Future<void> checkAndRedirectLogin(BuildContext context) async {
+  WidgetsBinding.instance.addPostFrameCallback((_) async {
+    try {
+      final webId = await getWebId();
+      if (webId == null && context.mounted) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const SolidLogin(
+              required: false,
+              title: 'HEALTH POD',
+              image: AssetImage('assets/images/healthpod_image.png'),
+              logo: AssetImage('assets/images/healthpod_logo.png'),
+              link: 'https://github.com/anusii/healthpod/blob/main/README.md',
+              child: HealthPodHome(), 
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      debugPrint('Error in checkAndRedirectLogin: $e');
+    }
+  });
+}


### PR DESCRIPTION
## Pull Request Details
# What issue does this PR address
- Implemented logout functionality with redirection to `SolidLogin` screen after successful logout
- Added error handling to display feedback for logout failures
- Centralised logout and login status checks into `session_utils.dart` for resuability and maintainability

Link to associated issue: https://github.com/anusii/healthpod/issues/12

# Checklist
Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (make prep or flutter analyze lib)
- [x] Tested on at least one device
  - [x] Windows
- [ ] Added 2 reviewers (or 1 for private repositories then they add another)