### PR TITLE
feat: Initialise healthpod folder structure on interact with POD

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -21,18 +21,17 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Kevin Wang, Graham Williams
+/// Authors: Kevin Wang, Graham Williams, Ashley Tang
 
 library;
 
 import 'package:flutter/material.dart';
+import 'package:healthpod/utils/session_utils.dart'; 
 
 import 'package:healthpod/constants/colours.dart';
 import 'package:healthpod/widgets/icon_grid_page.dart';
 
 class HealthPodHome extends StatefulWidget {
-  /// Constructor for the home screen.
-
   const HealthPodHome({super.key});
 
   @override
@@ -52,6 +51,13 @@ class HealthPodHomeState extends State<HealthPodHome> {
         title: const Text('Your Health - Your Data - You Decide ... '),
         backgroundColor: titleBackgroundColor,
         automaticallyImplyLeading: false,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            tooltip: 'Logout',
+            onPressed: () => handleLogout(context), 
+          ),
+        ],
       ),
       backgroundColor: titleBackgroundColor,
       body: IconGridPage(),

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -55,7 +55,7 @@ class HealthPodHomeState extends State<HealthPodHome> {
           IconButton(
             icon: const Icon(Icons.logout),
             tooltip: 'Logout',
-            onPressed: () => handleLogout(context), 
+            onPressed: () => handleLogout(context),
           ),
         ],
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -58,11 +58,17 @@ class HealthPod extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    checkAndRedirectLogin(context); // Use the utility function.
-    return const MaterialApp(
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
       title: 'Solid Health Pod',
-      home: SelectionArea(
-        child: HealthPodHome(),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            // Redirect the user to login if they are not logged in
+            checkAndRedirectLogin(context);
+            return const HealthPodHome();
+          },
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,52 +21,27 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Graham Williams
+/// Authors: Graham Williams, Ashley Tang
 
 library;
 
 import 'package:flutter/material.dart';
-
-import 'package:solidpod/solidpod.dart';
 import 'package:window_manager/window_manager.dart';
-
 import 'package:healthpod/home.dart';
 import 'package:healthpod/utils/is_desktop.dart';
+import 'package:healthpod/utils/session_utils.dart'; 
+
+
 
 void main() async {
-  // This is the main entry point for the app. The [async] is required because
-  // we asynchronously [await] the window manager below. Often, `main()` will
-  // simply include just [runApp].
-
   if (isDesktop(PlatformWrapper())) {
-    // Suport [windowManager] options for the desktop. We do this here before
-    // running the app. If there is no [windowManager] options we probably don't
-    // need this whole section.
-
-    // Enusre things are set up properly since we haven't yet initialised the
-    // app with [runApp].
-
     WidgetsFlutterBinding.ensureInitialized();
-
     await windowManager.ensureInitialized();
 
     const windowOptions = WindowOptions(
-      // We can set various desktop window options here.
-
-      // Setting [alwaysOnTop] here will ensure the app starts on top of other
-      // apps on the desktop so that it is visible (otherwise, Ubuuntu with
-      // GNOME it is often lost below other windows on startup which can be a
-      // little disconcerting). We later turn it off as we don't want to force
-      // it always on top.
-
       alwaysOnTop: true,
-
-      // The [title] is used for the window manager's window title.
-
       title: 'HealthPod - Private Solid Pod for Storing Key-Value Pairs',
     );
-
-    // Once the window manager is ready we recofigure it a little.
 
     await windowManager.waitUntilReadyToShow(windowOptions, () async {
       await windowManager.show();
@@ -75,59 +50,19 @@ void main() async {
     });
   }
 
-  // Ready to run the app.
-
   runApp(const HealthPod());
 }
-
-// The main widget could be in a separate file, but handy having it in main and
-// the file is not too large. The widget essentially orchestrates the building
-// of other widgets. Generically we set up to build a `Home()` widget containing
-// the App. For SolidPod we wrap the `Home()` widget within the `SolidLogin()`
-// widget so we start with a login screen, though this is optional.
 
 class HealthPod extends StatelessWidget {
   const HealthPod({super.key});
 
-  // This StatelessWidget is the root of our application.
-
   @override
   Widget build(BuildContext context) {
+    checkAndRedirectLogin(context); // Use the utility function.
     return const MaterialApp(
       title: 'Solid Health Pod',
       home: SelectionArea(
-        // Wrap the whole app inside a SelectionArea to ensure we get selectable
-        // text, for text that can be selected, as a default.
-
-        child: SolidLogin(
-          // Wrap the actual home widget within a [SolidLogin].
-
-          // If the app has functionality that does not require access to Pod
-          // data then [required] can be `false`. If the user connects to their
-          // Pod then their session information will be saved to save having to
-          // log in everytime. The login token and the security key are (optionally)
-          // cached so that the login information is not required every time.
-          //
-          // In this demo app we allow the CONTINUE button so as to demonstrate
-          // the use of [SolidLoginPopup] during the app session. If we want to
-          // save the data to the Pod or view data from the Pod, then if the
-          // user did not log in during startup we can call [SolidLoginPopup] to
-          // establish the connection at that time.
-
-          required: false,
-
-          title: 'HEALTH POD',
-          image: AssetImage('assets/images/healthpod_image.png'),
-          logo: AssetImage('assets/images/healthpod_logo.png'),
-          link: 'https://github.com/anusii/healthpod/blob/main/README.md',
-          infoButtonStyle: InfoButtonStyle(
-            tooltip: 'Visit the HealthPod documentation.',
-          ),
-          loginButtonStyle: LoginButtonStyle(
-            background: Colors.lightGreenAccent,
-          ),
-          child: HealthPodHome(),
-        ),
+        child: HealthPodHome(),
       ),
     );
   }

--- a/lib/services/file_service.dart
+++ b/lib/services/file_service.dart
@@ -1,0 +1,378 @@
+/// A widget to demonstrate the upload, download, and delete large files.
+///
+/// Copyright (C) 2024, Software Innovation Institute, ANU.
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License").
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Dawei Chen
+
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:solidpod/solidpod.dart';
+
+import 'package:healthpod/dialogs/alert.dart';
+
+class FileService extends StatefulWidget {
+  const FileService({super.key});
+
+  @override
+  State<FileService> createState() => _FileServiceState();
+}
+
+class _FileServiceState extends State<FileService> {
+  String remoteFileName = 'large_file.bin';
+  String? uploadFile;
+  String? downloadFile;
+  String? remoteFileUrl;
+
+  double uploadPercent = 0.0;
+  double downloadPercent = 0.0;
+  double deletePercent = 0.0;
+
+  bool uploadDone = false;
+  bool downloadDone = false;
+  bool deleteDone = false;
+
+  bool uploadInProgress = false;
+  bool downloadInProgress = false;
+  bool deleteInProgress = false;
+
+  final smallGapH = const SizedBox(width: 10);
+  final smallGapV = const SizedBox(height: 10);
+  final largeGapV = const SizedBox(height: 50);
+
+  Future<String> getRemoteFileUrl() async =>
+      getFileUrl([await getDataDirPath(), remoteFileName].join('/'));
+
+  Widget getProgressBar(String message, bool isDone, double percent) {
+    const textStyle = TextStyle(
+      color: Colors.green,
+      fontWeight: FontWeight.bold,
+    );
+
+    final prefix = Text(message, style: textStyle);
+    final suffix = Text('${(percent * 100).toInt()}%', style: textStyle);
+    final progress = SizedBox(
+      width: 300,
+      height: 10,
+      child: LinearProgressIndicator(
+        value: percent,
+        minHeight: 2,
+        backgroundColor: Colors.black12,
+        color: Colors.greenAccent,
+      ),
+    );
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      // crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        prefix,
+        smallGapH,
+        progress,
+        smallGapH,
+        suffix,
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final browseButton = ElevatedButton(
+      onPressed: () async {
+        final result = await FilePicker.platform.pickFiles();
+        if (result != null) {
+          setState(() {
+            uploadFile = result.files.single.path!;
+            uploadDone = false;
+            uploadPercent = 0.0;
+          });
+        }
+      },
+      child: const Text('Browse'),
+    );
+
+    final uploadButton = ElevatedButton(
+      onPressed: (uploadFile == null ||
+              uploadInProgress ||
+              downloadInProgress ||
+              deleteInProgress)
+          ? null
+          : () async {
+              try {
+                remoteFileUrl ??= await getRemoteFileUrl();
+                setState(() {
+                  uploadInProgress = true;
+                });
+                await sendLargeFile(
+                    localFilePath: uploadFile!,
+                    remoteFileName: remoteFileName,
+                    onProgress: (sent, total) {
+                      setState(() {
+                        uploadDone = sent == total;
+                        uploadPercent = sent / total;
+                      });
+                    }, context: context, child: const Text('Upload'));
+                if (uploadDone) {
+                  setState(() {
+                    uploadInProgress = false;
+                  });
+                }
+              } on Object catch (e) {
+                if (context.mounted) alert(context, 'Failed to send file.');
+                debugPrint('$e');
+              }
+            },
+      child: const Text('Upload'),
+    );
+
+    final downloadButton = ElevatedButton(
+      onPressed: (uploadInProgress || downloadInProgress || deleteInProgress)
+          ? null
+          : () async {
+              String? outputFile = await FilePicker.platform.saveFile(
+                dialogTitle: 'Please set the output file:',
+                // fileName: 'download.bin',
+              );
+              if (outputFile == null) {
+                // User canceled the picker
+                debugPrint('Download is cancelled');
+              } else {
+                setState(() {
+                  downloadFile = outputFile;
+                });
+                try {
+                  remoteFileUrl ??= await getRemoteFileUrl();
+                  setState(() {
+                    downloadInProgress = true;
+                  });
+                  await getLargeFile(
+                      remoteFileName: remoteFileName,
+                      localFilePath: outputFile,
+                      onProgress: (received, total) {
+                        setState(() {
+                          downloadDone = received == total;
+                          downloadPercent = received / total;
+                        });
+                      }, context: context, child: const Text('Download'));
+                  if (downloadDone) {
+                    setState(() {
+                      downloadInProgress = false;
+                    });
+                  }
+                } on Object catch (e) {
+                  if (context.mounted) {
+                    alert(context, 'Failed to download file.');
+                  }
+                  debugPrint('$e');
+                }
+              }
+            },
+      child: const Text('Download'),
+    );
+
+    final deleteButton = ElevatedButton(
+      onPressed: (uploadInProgress || downloadInProgress || deleteInProgress)
+          ? null
+          : () async {
+              try {
+                remoteFileUrl ??= await getRemoteFileUrl();
+                setState(() {
+                  deleteInProgress = true;
+                });
+                await deleteLargeFile(
+                    remoteFileName: remoteFileName,
+                    onProgress: (deleted, total) {
+                      setState(() {
+                        deleteDone = deleted == total;
+                        deletePercent = deleted / total;
+                      });
+                    }, context: context, child: const Text('Delete'));
+                if (deleteDone) {
+                  setState(() {
+                    deleteInProgress = false;
+                  });
+                }
+              } on Object catch (e) {
+                if (context.mounted) {
+                  alert(context, 'Failed to delete file.');
+                }
+                debugPrint('$e');
+              }
+            },
+      child: const Text('Delete'),
+    );
+
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Stack(
+          children: <Widget>[
+            Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                largeGapV,
+                largeGapV,
+
+                // Upload
+
+                Text(
+                  'Upload a large file and save it as "$remoteFileName" in POD',
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                smallGapV,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    const Text('Upload file'),
+                    smallGapH,
+                    Text(
+                      uploadFile ?? 'Click the Browse button to choose a file',
+                      style: TextStyle(
+                        color: uploadFile == null ? Colors.red : Colors.blue,
+                        // fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                    smallGapH,
+                    if (uploadDone) const Icon(Icons.done, color: Colors.green),
+                  ],
+                ),
+                smallGapV,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    browseButton,
+                    smallGapH,
+                    uploadButton,
+                  ],
+                ),
+
+                largeGapV,
+
+                // Download
+
+                Text(
+                  'Download the "$remoteFileName" from POD',
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                smallGapV,
+                if (downloadFile != null)
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      const Text('Save file'),
+                      smallGapH,
+                      Text(
+                        downloadFile!,
+                        style: const TextStyle(color: Colors.blue),
+                      ),
+                      smallGapH,
+                      if (downloadDone)
+                        const Icon(Icons.done, color: Colors.green),
+                    ],
+                  ),
+                smallGapV,
+                downloadButton,
+
+                largeGapV,
+
+                // Delete
+
+                Text(
+                  'Delete the "$remoteFileName" from POD',
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                smallGapV,
+                if (deleteInProgress || deleteDone)
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      const Text('Delete file'),
+                      smallGapH,
+                      Text(
+                        remoteFileUrl!,
+                        style: const TextStyle(color: Colors.blue),
+                      ),
+                      smallGapH,
+                      if (deleteDone)
+                        const Icon(Icons.done, color: Colors.green),
+                    ],
+                  ),
+                smallGapV,
+                deleteButton,
+              ],
+            ),
+
+            // Uploading progress bar
+
+            if (uploadInProgress)
+              Positioned(
+                top: 20,
+                left: 0,
+                right: 0,
+                child: getProgressBar('Uploading:', uploadDone, uploadPercent),
+              ),
+
+            // Downloading progress bar
+
+            if (downloadInProgress)
+              Positioned(
+                top: 20,
+                left: 0,
+                right: 0,
+                child: getProgressBar(
+                    'Downloading:', downloadDone, downloadPercent),
+              ),
+
+            // Deleting progress bar
+
+            if (deleteInProgress)
+              Positioned(
+                top: 20,
+                left: 0,
+                right: 0,
+                child: getProgressBar('Deleting:', deleteDone, deletePercent),
+              ),
+
+            // Navigate back to demo page
+            Positioned(
+              top: 10,
+              left: 10,
+              child: ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Back to Home'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/session_utils.dart
+++ b/lib/utils/session_utils.dart
@@ -13,6 +13,7 @@ Future<void> handleLogout(BuildContext context) async {
       context,
       MaterialPageRoute(
         builder: (context) => const SolidLogin(
+          appDirectory: 'healthpod/docs',
           required: false,
           title: 'HEALTH POD',
           image: AssetImage('assets/images/healthpod_image.png'),
@@ -44,7 +45,7 @@ Future<void> checkAndRedirectLogin(BuildContext context) async {
               image: AssetImage('assets/images/healthpod_image.png'),
               logo: AssetImage('assets/images/healthpod_logo.png'),
               link: 'https://github.com/anusii/healthpod/blob/main/README.md',
-              child: HealthPodHome(), 
+              child: HealthPodHome(),
             ),
           ),
         );
@@ -53,4 +54,14 @@ Future<void> checkAndRedirectLogin(BuildContext context) async {
       debugPrint('Error in checkAndRedirectLogin: $e');
     }
   });
+}
+
+/// Safe wrapper for `getWebId` to handle exceptions gracefully.
+Future<String?> safeGetWebId() async {
+  try {
+      return await getWebId();
+    } catch (e) {
+      debugPrint('Error fetching WebID: $e');
+      return null;
+  }
 }

--- a/lib/utils/session_utils.dart
+++ b/lib/utils/session_utils.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:healthpod/home.dart';
+import 'package:solidpod/solidpod.dart' show SolidLogin, getWebId, logoutPopup;
+
+/// Handles logout and navigates to the login screen
+Future<void> handleLogout(BuildContext context) async {
+  await logoutPopup(context, const HealthPodHome()); 
+
+  // Check login status using getWebId
+  final webId = await getWebId();
+  if (webId == null && context.mounted) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const SolidLogin(
+          required: false,
+          title: 'HEALTH POD',
+          image: AssetImage('assets/images/healthpod_image.png'),
+          logo: AssetImage('assets/images/healthpod_logo.png'),
+          link: 'https://github.com/anusii/healthpod/blob/main/README.md',
+          child: HealthPodHome(), 
+        ),
+      ),
+    );
+  } else if (context.mounted) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Logout failed. Please try again.')),
+    );
+  }
+}
+
+/// Checks if the user is logged in and navigates appropriately
+Future<void> checkAndRedirectLogin(BuildContext context) async {
+  WidgetsBinding.instance.addPostFrameCallback((_) async {
+    try {
+      final webId = await getWebId();
+      if (webId == null && context.mounted) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const SolidLogin(
+              required: false,
+              title: 'HEALTH POD',
+              image: AssetImage('assets/images/healthpod_image.png'),
+              logo: AssetImage('assets/images/healthpod_logo.png'),
+              link: 'https://github.com/anusii/healthpod/blob/main/README.md',
+              child: HealthPodHome(), 
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      debugPrint('Error in checkAndRedirectLogin: $e');
+    }
+  });
+}

--- a/lib/widgets/icon_grid_page.dart
+++ b/lib/widgets/icon_grid_page.dart
@@ -28,21 +28,14 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:healthpod/dialogs/show_comming_soon.dart';
+import 'package:healthpod/services/file_service.dart';
 
 class IconGridPage extends StatelessWidget {
   final List<IconData> icons = [
     Icons.home,
     Icons.star,
     Icons.settings,
-    Icons.phone,
-    Icons.email,
-    Icons.camera_alt,
-    Icons.map,
-    Icons.music_note,
-    Icons.shopping_cart,
-    Icons.work,
-    Icons.wifi,
-    Icons.alarm,
+    Icons.folder,
   ];
 
   IconGridPage({super.key});
@@ -60,7 +53,16 @@ class IconGridPage extends StatelessWidget {
           runSpacing: 10.0, // Space between icons vertically
           children: icons.map((icon) {
             return GestureDetector(
-              onTap: () => showComingSoon(context),
+              onTap: () {
+                if (icon == Icons.folder) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => const FileService()),
+                  );
+                }  else {
+                  showComingSoon(context); // For other icons.
+                }
+              },
               child: Container(
                 width: 80.0, // Fixed width for each icon container
                 height: 80.0, // Fixed height for each icon container

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ environment:
 # available, run `flutter pub outdated`.
 
 dependencies:
+  file_picker: ^8.1.7
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,29 +6,24 @@ version: 0.0.1+1
 environment:
   sdk: ">=3.2.3 <4.0.0"
 
-# Dependencies specify other packages that your package needs in order
-# to work.  To automatically upgrade your package dependencies to the
-# latest versions consider running `flutter pub upgrade
-# --major-versions`. Alternatively, dependencies can be manually
-# updated by changing the version numbers below to the latest version
-# available on pub.dev. To see which dependencies have newer versions
-# available, run `flutter pub outdated`.
+# To automatically upgrade package dependencies:
+#
+# `flutter pub upgrade --major-versions`.
+#
+# To see which dependencies have newer versions available:
+#
+# `flutter pub outdated`.
 
 dependencies:
-  file_picker: ^8.1.7
   flutter:
     sdk: flutter
 
+  file_picker: ^8.1.7
   flutter_launcher_icons: ^0.13.1
   flutter_markdown: ^0.7.3
   path: ^1.9.0
   rdflib: ^0.2.9
-
-  solidpod:
-    git:
-      url: https://github.com/anusii/solidpod
-      ref: dev
-
+  solidpod: ^0.6.4
   universal_io: ^2.2.2
   window_manager: ^0.3.9
 
@@ -42,42 +37,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  # Mockito is used for mock up testing. See `test/mocks.dart`.
-
-  mockito: ^5.4.4
-
   ubuntu_lints: ^0.4.0
 
-dependency_overrides:
-  # TODO 20240710 gjw dart-code-metrics DEPENDENCY ON pub_updater PROBLEM
-  #
-  # If Zheyuan can fix his dart-code-metrics fork this can probably be
-  # removed.
-  
-  file: ^7.0.0 # Use only if necessary
-
-  # TODO 20240710 gjw solid-auth DEPENDS ON intl-0.19.0
-  #
-  # This may require Anushka's update. We will want to remove this
-  # override asap.
-  
-  intl: ^0.19.0 
-
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
-
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
-
   uses-material-design: true
-
-  # Add assets to the app.
-
   assets:
     - assets/images/healthpod_image.png
     - assets/images/healthpod_logo.png
@@ -101,4 +64,3 @@ flutter_launcher_icons:
   windows:
     generate: true
     icon_size: 48 # min:48, max:256, default: 48
-


### PR DESCRIPTION
## Pull Request Details
# What issue does this PR address
- Implement initialisation of the healthpod/docs folder structure upon interaction with the user's POD.
- Introduced utilities to verify and initialise the folder structure (pod_utils.dart).
- Added UI for folder management (file_service.dart) accessible from the home screen.
- Included retry logic for verifying folder initialisation to handle async delays with the Solid POD API.

Link to associated issue: https://github.com/anusii/healthpod/issues/10

# Checklist
Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (make prep or flutter analyze lib)
- [x] Tested on at least one device
  - [x] Windows
- [ ] Added 2 reviewers (or 1 for private repositories then they add another)