### PR TITLE
Use readPod and writePod for file service

### DIFF
--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -29,6 +29,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'package:file_picker/file_picker.dart';
+import 'package:healthpod/widgets/preview.dart';
 import 'package:path/path.dart' as path;
 import 'package:solidpod/solidpod.dart';
 
@@ -456,7 +457,14 @@ class _FileServiceState extends State<FileService> {
               
                   // Preview section.
               
-                  if (showPreview) _buildPreviewDialog(),
+                  if (showPreview)
+                    PreviewDialog(
+                      uploadFile: uploadFile, 
+                      filePreview: filePreview, 
+                      onClose: () { 
+                        setState(() { showPreview = false; }); 
+                      },
+                    ),
               
                   largeGapV,
                   
@@ -570,68 +578,6 @@ class _FileServiceState extends State<FileService> {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPreviewDialog() {
-    return Dialog(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxWidth: 600,
-          maxHeight: MediaQuery.of(context).size.height * 0.8,  // 80% of screen height
-        ),
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,  
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(  
-                    child: Text(
-                      'Preview: ${path.basename(uploadFile ?? '')}',
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
-                      ),
-                      overflow: TextOverflow.ellipsis,  // Handles long filenames
-                    ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    padding: EdgeInsets.zero,  
-                    onPressed: () {
-                      setState(() {
-                        showPreview = false;
-                      });
-                    },
-                  ),
-                ],
-              ),
-              const Divider(height: 16), 
-              Flexible(  
-                child: SingleChildScrollView(
-                  child: Container(
-                    width: double.infinity,  
-                    padding: const EdgeInsets.all(8),
-                    decoration: BoxDecoration(
-                      color: Colors.grey[100],
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: SelectableText(  
-                      filePreview ?? 'No preview available',
-                      style: const TextStyle(
-                        fontFamily: 'monospace',
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
         ),
       ),
     );

--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -33,7 +33,8 @@ import 'package:healthpod/widgets/preview.dart';
 import 'package:path/path.dart' as path;
 import 'package:solidpod/solidpod.dart';
 
-import 'package:healthpod/dialogs/alert.dart';
+import 'package:healthpod/utils/is_text_file.dart';
+import 'package:healthpod/utils/show_alert.dart';
 
 class FileService extends StatefulWidget {
   const FileService({super.key});
@@ -66,34 +67,6 @@ class _FileServiceState extends State<FileService> {
   final smallGapH = const SizedBox(width: 10);
   final smallGapV = const SizedBox(height: 10);
   final largeGapV = const SizedBox(height: 50);
-
-  // File type detection.
-
-  final textFileExtensions = [
-    '.txt',
-    '.md',
-    '.json',
-    '.xml',
-    '.csv',
-    '.html',
-    '.css',
-    '.js',
-    '.dart',
-    '.yaml',
-    '.yml'
-  ];
-
-  bool isTextFile(String filePath) {
-    return textFileExtensions.contains(path.extension(filePath).toLowerCase());
-  }
-
-  // Helper method to show alerts safely.
-
-  void _showAlert(BuildContext context, String message) {
-    if (context.mounted) {
-      alert(context, message);
-    }
-  }
 
   Future<void> handleUpload() async {
     if (uploadFile == null) return;
@@ -138,12 +111,12 @@ class _FileServiceState extends State<FileService> {
       });
 
       if (result != SolidFunctionCallStatus.success && mounted) {
-        _showAlert(context,
+        showAlert(context,
             'Upload failed - please check your connection and permissions.');
       }
     } catch (e) {
       if (!mounted) return;
-      _showAlert(context, 'Upload error: ${e.toString()}');
+      showAlert(context, 'Upload error: ${e.toString()}');
       debugPrint('Upload error: $e');
     } finally {
       if (mounted) {
@@ -207,7 +180,7 @@ class _FileServiceState extends State<FileService> {
       }
     } catch (e) {
       if (!mounted) return;
-      _showAlert(context, e.toString().replaceAll('Exception: ', ''));
+      showAlert(context, e.toString().replaceAll('Exception: ', ''));
       debugPrint('Download error: $e');
     } finally {
       if (mounted) {
@@ -248,7 +221,7 @@ class _FileServiceState extends State<FileService> {
       });
     } catch (e) {
       if (!mounted) return;
-      _showAlert(context, 'Failed to preview file: ${e.toString()}');
+      showAlert(context, 'Failed to preview file: ${e.toString()}');
       debugPrint('Preview error: $e');
     }
   }
@@ -312,7 +285,7 @@ class _FileServiceState extends State<FileService> {
           ? 'File not found or already deleted'
           : 'Delete failed: ${e.toString()}';
 
-      _showAlert(context, message);
+      showAlert(context, message);
       debugPrint('Delete error: $e');
     } finally {
       if (mounted) {

--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -34,7 +34,6 @@ import 'package:solidpod/solidpod.dart';
 
 import 'package:healthpod/dialogs/alert.dart';
 
-
 class FileService extends StatefulWidget {
   const FileService({super.key});
 
@@ -67,8 +66,19 @@ class _FileServiceState extends State<FileService> {
 
   // File type detection.
 
-  final textFileExtensions = ['.txt', '.md', '.json', '.xml', '.csv', '.html', 
-                            '.css', '.js', '.dart', '.yaml', '.yml'];
+  final textFileExtensions = [
+    '.txt',
+    '.md',
+    '.json',
+    '.xml',
+    '.csv',
+    '.html',
+    '.css',
+    '.js',
+    '.dart',
+    '.yaml',
+    '.yml'
+  ];
 
   bool isTextFile(String filePath) {
     return textFileExtensions.contains(path.extension(filePath).toLowerCase());
@@ -103,14 +113,13 @@ class _FileServiceState extends State<FileService> {
         fileContent = base64Encode(bytes);
       }
 
-      remoteFileName = '${path.basename(uploadFile!)
-          .replaceAll(RegExp(r'[^a-zA-Z0-9._-]'), '_')
-          .replaceAll(RegExp(r'\.enc\.ttl$'), '')}.enc.ttl';
+      remoteFileName =
+          '${path.basename(uploadFile!).replaceAll(RegExp(r'[^a-zA-Z0-9._-]'), '_').replaceAll(RegExp(r'\.enc\.ttl$'), '')}.enc.ttl';
 
       if (!mounted) return;
 
       // Upload with encryption.
-      
+
       final result = await writePod(
         remoteFileName!,
         fileContent,
@@ -126,7 +135,8 @@ class _FileServiceState extends State<FileService> {
       });
 
       if (result != SolidFunctionCallStatus.success && mounted) {
-        _showAlert(context, 'Upload failed - please check your connection and permissions.');
+        _showAlert(context,
+            'Upload failed - please check your connection and permissions.');
       }
     } catch (e) {
       if (!mounted) return;
@@ -163,16 +173,18 @@ class _FileServiceState extends State<FileService> {
 
       if (!mounted) return;
 
-      if (fileContent == SolidFunctionCallStatus.fail || 
+      if (fileContent == SolidFunctionCallStatus.fail ||
           fileContent == SolidFunctionCallStatus.notLoggedIn) {
-        throw Exception('Download failed - please check your connection and permissions');
+        throw Exception(
+            'Download failed - please check your connection and permissions');
       }
 
       final saveFileName = downloadFile!.replaceAll(RegExp(r'\.enc\.ttl$'), '');
       final file = File(saveFileName);
-      
+
       try {
-        if (isTextFile(remoteFileName!.replaceAll(RegExp(r'\.enc\.ttl$'), ''))) {
+        if (isTextFile(
+            remoteFileName!.replaceAll(RegExp(r'\.enc\.ttl$'), ''))) {
           await file.writeAsString(fileContent.toString());
         } else {
           try {
@@ -216,7 +228,7 @@ class _FileServiceState extends State<FileService> {
       final basePath = '$dataDir/$remoteFileName';
 
       if (!mounted) return;
-      
+
       bool mainFileDeleted = false;
       try {
         await deleteFile(basePath);
@@ -224,7 +236,7 @@ class _FileServiceState extends State<FileService> {
         debugPrint('Successfully deleted main file: $basePath');
       } catch (e) {
         debugPrint('Error deleting main file: $e');
-        if (!e.toString().contains('404') && 
+        if (!e.toString().contains('404') &&
             !e.toString().contains('NotFoundHttpError')) {
           rethrow;
         }
@@ -237,14 +249,14 @@ class _FileServiceState extends State<FileService> {
           await deleteFile('$basePath.acl');
           debugPrint('Successfully deleted ACL file');
         } catch (e) {
-          if (e.toString().contains('404') || 
+          if (e.toString().contains('404') ||
               e.toString().contains('NotFoundHttpError')) {
             debugPrint('ACL file not found (safe to ignore)');
           } else {
             debugPrint('Error deleting ACL file: ${e.toString()}');
           }
         }
-        
+
         if (!mounted) return;
         setState(() {
           deleteDone = true;
@@ -252,16 +264,16 @@ class _FileServiceState extends State<FileService> {
       }
     } catch (e) {
       if (!mounted) return;
-      
+
       setState(() {
         deleteDone = false;
       });
 
-      final message = e.toString().contains('404') || 
-                     e.toString().contains('NotFoundHttpError')
+      final message = e.toString().contains('404') ||
+              e.toString().contains('NotFoundHttpError')
           ? 'File not found or already deleted'
           : 'Delete failed: ${e.toString()}';
-      
+
       _showAlert(context, message);
       debugPrint('Delete error: $e');
     } finally {
@@ -419,7 +431,8 @@ class _FileServiceState extends State<FileService> {
                     children: <Widget>[
                       Text('Delete file'),
                       smallGapH,
-                      Text('$remoteFileName', style: const TextStyle(color: Colors.red)),
+                      Text('$remoteFileName',
+                          style: const TextStyle(color: Colors.red)),
                       smallGapH,
                       Text(
                         remoteFileUrl ?? '',

--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -231,12 +231,14 @@ class _FileServiceState extends State<FileService> {
         content = await file.readAsString();
 
         // Take first 500 characters or less.
-        content = content.length > 500 ? '${content.substring(0, 500)}...' : content;
+        content =
+            content.length > 500 ? '${content.substring(0, 500)}...' : content;
       } else {
         // For binary files, show basic info.
 
         final bytes = await file.readAsBytes();
-        content = 'Binary file\nSize: ${(bytes.length / 1024).toStringAsFixed(2)} KB\nType: ${path.extension(uploadFile!)}';
+        content =
+            'Binary file\nSize: ${(bytes.length / 1024).toStringAsFixed(2)} KB\nType: ${path.extension(uploadFile!)}';
       }
 
       if (!mounted) return;
@@ -368,7 +370,6 @@ class _FileServiceState extends State<FileService> {
       child: const Text('Preview'),
     );
 
-
     final downloadButton = ElevatedButton(
       onPressed: (uploadInProgress || downloadInProgress || deleteInProgress)
           ? null
@@ -415,9 +416,9 @@ class _FileServiceState extends State<FileService> {
                 children: <Widget>[
                   largeGapV,
                   largeGapV,
-              
+
                   // Upload section.
-              
+
                   Text(
                     'Upload a file and save it as "$remoteFileName" in POD',
                     style: const TextStyle(
@@ -432,13 +433,15 @@ class _FileServiceState extends State<FileService> {
                       const Text('Upload file'),
                       smallGapH,
                       Text(
-                        uploadFile ?? 'Click the Browse button to choose a file',
+                        uploadFile ??
+                            'Click the Browse button to choose a file',
                         style: TextStyle(
                           color: uploadFile == null ? Colors.red : Colors.blue,
                         ),
                       ),
                       smallGapH,
-                      if (uploadDone) const Icon(Icons.done, color: Colors.green),
+                      if (uploadDone)
+                        const Icon(Icons.done, color: Colors.green),
                     ],
                   ),
                   smallGapV,
@@ -452,24 +455,26 @@ class _FileServiceState extends State<FileService> {
                       uploadButton,
                     ],
                   ),
-              
+
                   largeGapV,
-              
+
                   // Preview section.
-              
+
                   if (showPreview)
                     PreviewDialog(
-                      uploadFile: uploadFile, 
-                      filePreview: filePreview, 
-                      onClose: () { 
-                        setState(() { showPreview = false; }); 
+                      uploadFile: uploadFile,
+                      filePreview: filePreview,
+                      onClose: () {
+                        setState(() {
+                          showPreview = false;
+                        });
                       },
                     ),
-              
+
                   largeGapV,
-                  
+
                   // Download section.
-              
+
                   Text(
                     'Download "$remoteFileName" from POD',
                     style: const TextStyle(
@@ -502,11 +507,11 @@ class _FileServiceState extends State<FileService> {
                       previewButton,
                     ],
                   ),
-              
+
                   largeGapV,
-              
+
                   // Delete section.
-              
+
                   Text(
                     'Delete "$remoteFileName" from POD',
                     style: const TextStyle(

--- a/lib/utils/is_text_file.dart
+++ b/lib/utils/is_text_file.dart
@@ -1,0 +1,46 @@
+/// Check if a file is a text file.
+//
+// Time-stamp: <Thursday 2024-12-19 13:33:06 +1100 Graham Williams>
+//
+/// Copyright (C) 2025, Software Innovation Institute, ANU
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Ashley Tang
+
+library;
+
+import 'package:path/path.dart' as path;
+
+final textFileExtensions = [
+  '.txt',
+  '.md',
+  '.json',
+  '.xml',
+  '.csv',
+  '.html',
+  '.css',
+  '.js',
+  '.dart',
+  '.yaml',
+  '.yml'
+];
+
+bool isTextFile(String filePath) {
+  return textFileExtensions.contains(path.extension(filePath).toLowerCase());
+}

--- a/lib/utils/show_alert.dart
+++ b/lib/utils/show_alert.dart
@@ -28,6 +28,7 @@
 library;
 
 import 'package:flutter/material.dart';
+
 import 'package:healthpod/dialogs/alert.dart';
 
 void showAlert(BuildContext context, String message) {

--- a/lib/utils/show_alert.dart
+++ b/lib/utils/show_alert.dart
@@ -1,0 +1,37 @@
+/// Show alert safely.
+//
+// Time-stamp: <Thursday 2024-12-19 13:33:06 +1100 Graham Williams>
+//
+/// Copyright (C) 2025, Software Innovation Institute, ANU
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Ashley Tang
+
+// Helper method to show alerts safely.
+
+library;
+
+import 'package:flutter/material.dart';
+import 'package:healthpod/dialogs/alert.dart';
+
+void showAlert(BuildContext context, String message) {
+  if (context.mounted) {
+    alert(context, message);
+  }
+}

--- a/lib/widgets/preview.dart
+++ b/lib/widgets/preview.dart
@@ -25,7 +25,6 @@
 
 library;
 
-
 import 'package:flutter/material.dart';
 
 import 'package:path/path.dart' as path;
@@ -48,44 +47,45 @@ class PreviewDialog extends StatelessWidget {
       child: ConstrainedBox(
         constraints: BoxConstraints(
           maxWidth: 600,
-          maxHeight: MediaQuery.of(context).size.height * 0.8,  // 80% of screen height
+          maxHeight:
+              MediaQuery.of(context).size.height * 0.8, // 80% of screen height
         ),
         child: Container(
           padding: const EdgeInsets.all(16),
           child: Column(
-            mainAxisSize: MainAxisSize.min,  
+            mainAxisSize: MainAxisSize.min,
             children: [
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Expanded(  
+                  Expanded(
                     child: Text(
                       'Preview: ${path.basename(uploadFile ?? '')}',
                       style: const TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.bold,
                       ),
-                      overflow: TextOverflow.ellipsis,  // Handles long filenames
+                      overflow: TextOverflow.ellipsis, // Handles long filenames
                     ),
                   ),
                   IconButton(
                     icon: const Icon(Icons.close),
-                    padding: EdgeInsets.zero,  
+                    padding: EdgeInsets.zero,
                     onPressed: onClose,
                   ),
                 ],
               ),
-              const Divider(height: 16), 
-              Flexible(  
+              const Divider(height: 16),
+              Flexible(
                 child: SingleChildScrollView(
                   child: Container(
-                    width: double.infinity,  
+                    width: double.infinity,
                     padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       color: Colors.grey[100],
                       borderRadius: BorderRadius.circular(4),
                     ),
-                    child: SelectableText(  
+                    child: SelectableText(
                       filePreview ?? 'No preview available',
                       style: const TextStyle(
                         fontFamily: 'monospace',

--- a/lib/widgets/preview.dart
+++ b/lib/widgets/preview.dart
@@ -1,0 +1,103 @@
+/// Preview Dialog.
+//
+// Time-stamp: <Thursday 2024-12-19 13:33:06 +1100 Graham Williams>
+//
+/// Copyright (C) 2025, Software Innovation Institute, ANU
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Ashley Tang
+
+library;
+
+
+import 'package:flutter/material.dart';
+
+import 'package:path/path.dart' as path;
+
+class PreviewDialog extends StatelessWidget {
+  final String? uploadFile;
+  final String? filePreview;
+  final VoidCallback onClose;
+
+  const PreviewDialog({
+    super.key,
+    required this.uploadFile,
+    required this.filePreview,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: 600,
+          maxHeight: MediaQuery.of(context).size.height * 0.8,  // 80% of screen height
+        ),
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,  
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(  
+                    child: Text(
+                      'Preview: ${path.basename(uploadFile ?? '')}',
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      overflow: TextOverflow.ellipsis,  // Handles long filenames
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    padding: EdgeInsets.zero,  
+                    onPressed: onClose,
+                  ),
+                ],
+              ),
+              const Divider(height: 16), 
+              Flexible(  
+                child: SingleChildScrollView(
+                  child: Container(
+                    width: double.infinity,  
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[100],
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: SelectableText(  
+                      filePreview ?? 'No preview available',
+                      style: const TextStyle(
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Pull Request Details
Link to associated issue: https://github.com/anusii/healthpod/issues/20

- Switched from Large file methods (`sendLargeFile`, `getLargeFile`, `deleteLargeFile`) to POD methods (`writePod`, `readPod`, `deleteFile`)
- Changed file extension handling. Previously used `.bin` extension and now uses `.enc.ttl` for encrypted files
- Replaced progress bar implementation with circular progress indicator for operations
- Added improved file type detection via `textFileExtensions` list and `isTextFile` helper method

# Checklist
Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (make prep or flutter analyze lib)
- [x] Tested on at least one device
  - [x] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another) - 1 for now