### PR TITLE
Remove enc.ttl from save dialog

### DIFF
--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -207,7 +207,7 @@ class _FileServiceState extends State<FileService> {
         content = await file.readAsString();
 
         // Take first 500 characters or less.
-        
+
         content =
             content.length > 500 ? '${content.substring(0, 500)}...' : content;
       } else {
@@ -352,7 +352,7 @@ class _FileServiceState extends State<FileService> {
           ? null
           : () async {
               // Remove .enc.ttl from the suggested filename.
-            
+
               final suggestedName =
                   remoteFileName?.replaceAll(RegExp(r'\.enc\.ttl$'), '');
 

--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -507,7 +507,7 @@ class _FileServiceState extends State<FileService> {
                       children: <Widget>[
                         Text('Delete file'),
                         smallGapH,
-                        Text('$remoteFileName',
+                        Text('$cleanFileName',
                             style: const TextStyle(color: Colors.red)),
                         smallGapH,
                         Text(

--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Dawei Chen
+/// Authors: Dawei Chen, Ashley Tang
 
 library;
 
@@ -207,6 +207,7 @@ class _FileServiceState extends State<FileService> {
         content = await file.readAsString();
 
         // Take first 500 characters or less.
+        
         content =
             content.length > 500 ? '${content.substring(0, 500)}...' : content;
       } else {
@@ -350,7 +351,8 @@ class _FileServiceState extends State<FileService> {
       onPressed: (uploadInProgress || downloadInProgress || deleteInProgress)
           ? null
           : () async {
-              // Remove .enc.ttl from the suggested filename
+              // Remove .enc.ttl from the suggested filename.
+            
               final suggestedName =
                   remoteFileName?.replaceAll(RegExp(r'\.enc\.ttl$'), '');
 

--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -49,6 +49,7 @@ class _FileServiceState extends State<FileService> {
   String? uploadFile;
   String? downloadFile;
   String? remoteFileName = 'remoteFileName';
+  String? cleanFileName = 'remoteFileName';
   String? remoteFileUrl;
   String? filePreview;
 
@@ -91,6 +92,9 @@ class _FileServiceState extends State<FileService> {
 
       remoteFileName =
           '${path.basename(uploadFile!).replaceAll(RegExp(r'[^a-zA-Z0-9._-]'), '_').replaceAll(RegExp(r'\.enc\.ttl$'), '')}.enc.ttl';
+      
+      cleanFileName = remoteFileName?.replaceAll(RegExp(r'\.enc\.ttl$'), '');
+
 
       if (!mounted) return;
 
@@ -347,9 +351,12 @@ class _FileServiceState extends State<FileService> {
       onPressed: (uploadInProgress || downloadInProgress || deleteInProgress)
           ? null
           : () async {
+              // Remove .enc.ttl from the suggested filename
+              final suggestedName = remoteFileName?.replaceAll(RegExp(r'\.enc\.ttl$'), '');
+              
               String? outputFile = await FilePicker.platform.saveFile(
                 dialogTitle: 'Please set the output file:',
-                fileName: remoteFileName, // Suggest the original filename
+                fileName: suggestedName, // Clean filename without encryption suffix
               );
               if (outputFile != null) {
                 setState(() {
@@ -366,7 +373,7 @@ class _FileServiceState extends State<FileService> {
       ),
       child: const Text('Download'),
     );
-
+    
     final deleteButton = ElevatedButton(
       onPressed: (uploadInProgress || downloadInProgress || deleteInProgress)
           ? null
@@ -393,7 +400,7 @@ class _FileServiceState extends State<FileService> {
                   // Upload section.
 
                   Text(
-                    'Upload a file and save it as "$remoteFileName" in POD',
+                    'Upload a file and save it as "$cleanFileName" in POD',
                     style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
@@ -449,7 +456,7 @@ class _FileServiceState extends State<FileService> {
                   // Download section.
 
                   Text(
-                    'Download "$remoteFileName" from POD',
+                    'Download "$cleanFileName" from POD',
                     style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
@@ -486,7 +493,7 @@ class _FileServiceState extends State<FileService> {
                   // Delete section.
 
                   Text(
-                    'Delete "$remoteFileName" from POD',
+                    'Delete "$cleanFileName" from POD',
                     style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,

--- a/lib/features/file/service.dart
+++ b/lib/features/file/service.dart
@@ -92,9 +92,8 @@ class _FileServiceState extends State<FileService> {
 
       remoteFileName =
           '${path.basename(uploadFile!).replaceAll(RegExp(r'[^a-zA-Z0-9._-]'), '_').replaceAll(RegExp(r'\.enc\.ttl$'), '')}.enc.ttl';
-      
-      cleanFileName = remoteFileName?.replaceAll(RegExp(r'\.enc\.ttl$'), '');
 
+      cleanFileName = remoteFileName?.replaceAll(RegExp(r'\.enc\.ttl$'), '');
 
       if (!mounted) return;
 
@@ -352,11 +351,13 @@ class _FileServiceState extends State<FileService> {
           ? null
           : () async {
               // Remove .enc.ttl from the suggested filename
-              final suggestedName = remoteFileName?.replaceAll(RegExp(r'\.enc\.ttl$'), '');
-              
+              final suggestedName =
+                  remoteFileName?.replaceAll(RegExp(r'\.enc\.ttl$'), '');
+
               String? outputFile = await FilePicker.platform.saveFile(
                 dialogTitle: 'Please set the output file:',
-                fileName: suggestedName, // Clean filename without encryption suffix
+                fileName:
+                    suggestedName, // Clean filename without encryption suffix
               );
               if (outputFile != null) {
                 setState(() {
@@ -373,7 +374,7 @@ class _FileServiceState extends State<FileService> {
       ),
       child: const Text('Download'),
     );
-    
+
     final deleteButton = ElevatedButton(
       onPressed: (uploadInProgress || downloadInProgress || deleteInProgress)
           ? null


### PR DESCRIPTION
## Pull Request Details
Link to associated issue: https://github.com/anusii/healthpod/issues/20
- Dropped `enc.ttl` suffix from file name in save dialog and download dialog for clarity

# Checklist
Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (make prep or flutter analyze lib)
- [x] Tested on at least one device
  - [x] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another) - 1 for now