### PR TITLE
make footer server and login status text tappable

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -33,6 +33,7 @@ import 'package:healthpod/constants/colours.dart';
 import 'package:healthpod/dialogs/show_about.dart';
 import 'package:healthpod/utils/fetch_key_saved_status.dart';
 import 'package:healthpod/utils/fetch_web_id.dart';
+import 'package:healthpod/utils/get_footer_height.dart';
 import 'package:healthpod/utils/handle_logout.dart';
 import 'package:healthpod/widgets/icon_grid_page.dart';
 import 'package:healthpod/widgets/footer.dart';
@@ -111,7 +112,7 @@ class HealthPodHomeState extends State<HealthPodHome> {
       backgroundColor: titleBackgroundColor,
       body: IconGridPage(),
       bottomNavigationBar: BottomAppBar(
-        height: 60.0,
+        height: getFooterHeight(context),
         color: Colors.grey[200],
         child: SizedBox(
           child: Footer(

--- a/lib/utils/create_interactive_text.dart
+++ b/lib/utils/create_interactive_text.dart
@@ -1,0 +1,49 @@
+/// Creates interactive text with consistent configuration.
+//
+// Time-stamp: <Thursday 2024-12-19 13:33:06 +1100 Graham Williams>
+//
+/// Copyright (C) 2025, Software Innovation Institute, ANU
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Ashley Tang
+
+library;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+Widget createInteractiveText({
+  required BuildContext context,
+  required String text,
+  required VoidCallback? onTap,
+  TextStyle? style,
+  bool isClickable = true,
+}) {
+  return MouseRegion(
+    cursor: isClickable ? SystemMouseCursors.click : SystemMouseCursors.text,
+    child: SelectableText.rich(
+      TextSpan(
+        text: text,
+        style: style,
+        recognizer:
+            isClickable ? (TapGestureRecognizer()..onTap = onTap) : null,
+      ),
+    ),
+  );
+}

--- a/lib/utils/get_footer_height.dart
+++ b/lib/utils/get_footer_height.dart
@@ -28,20 +28,20 @@ library;
 import 'package:flutter/material.dart';
 
 double getFooterHeight(BuildContext context) {
-    final width = MediaQuery.of(context).size.width;
-    // For very narrow screens (mobile), use three lines.
+  final width = MediaQuery.of(context).size.width;
+  // For very narrow screens (mobile), use three lines.
 
-    if (width < 400) {
-      return 110.0;
-    }
-
-    // For medium screens, use two lines.
-
-    if (width < 600) {
-      return 70.0;
-    }
-
-    // For wider screens, use single line.
-
-    return 50.0;
+  if (width < 400) {
+    return 110.0;
   }
+
+  // For medium screens, use two lines.
+
+  if (width < 600) {
+    return 70.0;
+  }
+
+  // For wider screens, use single line.
+
+  return 50.0;
+}

--- a/lib/utils/get_footer_height.dart
+++ b/lib/utils/get_footer_height.dart
@@ -1,0 +1,47 @@
+/// Get footer height.
+//
+// Time-stamp: <Thursday 2024-12-19 13:33:06 +1100 Graham Williams>
+//
+/// Copyright (C) 2025, Software Innovation Institute, ANU
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Ashley Tang
+
+library;
+
+import 'package:flutter/material.dart';
+
+double getFooterHeight(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    // For very narrow screens (mobile), use three lines.
+
+    if (width < 400) {
+      return 110.0;
+    }
+
+    // For medium screens, use two lines.
+
+    if (width < 600) {
+      return 70.0;
+    }
+
+    // For wider screens, use single line.
+
+    return 50.0;
+  }

--- a/lib/utils/get_footer_height.dart
+++ b/lib/utils/get_footer_height.dart
@@ -38,10 +38,10 @@ double getFooterHeight(BuildContext context) {
   // For medium screens, use two lines.
 
   if (width < 600) {
-    return 70.0;
+    return 90.0;
   }
 
   // For wider screens, use single line.
 
-  return 50.0;
+  return 70.0;
 }

--- a/lib/widgets/footer.dart
+++ b/lib/widgets/footer.dart
@@ -39,29 +39,6 @@ class Footer extends StatelessWidget {
     required this.isKeySaved,
   });
 
-  @override
-  Widget build(BuildContext context) {
-    final serverUri = webId?.split('/profile')[0] ?? 'Not connected';
-    final loginStatus = webId == null ? "Not Logged In" : "Logged In";
-    final loginStatusColor = webId == null ? Colors.red : Colors.green;
-    final securityKeyStatus = isKeySaved ? "Saved" : "Not Saved";
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxWidth < 400) {
-          return _buildNarrowLayout(
-              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
-        } else if (constraints.maxWidth < 600) {
-          return _buildMediumLayout(
-              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
-        } else {
-          return _buildWideLayout(
-              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
-        }
-      },
-    );
-  }
-
   Widget _buildTextRow(String label, String value, {Color? valueColor}) {
     return Text(
       '$label: $value',
@@ -145,6 +122,29 @@ class Footer extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final serverUri = webId?.split('/profile')[0] ?? 'Not connected';
+    final loginStatus = webId == null ? "Not Logged In" : "Logged In";
+    final loginStatusColor = webId == null ? Colors.red : Colors.green;
+    final securityKeyStatus = isKeySaved ? "Saved" : "Not Saved";
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < 400) {
+          return _buildNarrowLayout(
+              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+        } else if (constraints.maxWidth < 600) {
+          return _buildMediumLayout(
+              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+        } else {
+          return _buildWideLayout(
+              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+        }
+      },
     );
   }
 }

--- a/lib/widgets/footer.dart
+++ b/lib/widgets/footer.dart
@@ -27,6 +27,12 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:healthpod/utils/create_solid_login.dart';
+import 'package:healthpod/utils/create_interactive_text.dart';
+import 'package:healthpod/utils/handle_logout.dart';
+
 /// Footer widget to display server information, login status, and security key status.
 
 class Footer extends StatelessWidget {
@@ -39,6 +45,12 @@ class Footer extends StatelessWidget {
     required this.isKeySaved,
   });
 
+  Future<void> _launchUrl(String url) async {
+    if (await canLaunchUrl(Uri.parse(url))) {
+      await launchUrl(Uri.parse(url));
+    }
+  }
+
   Widget _buildTextRow(String label, String value, {Color? valueColor}) {
     return Text(
       '$label: $value',
@@ -47,8 +59,41 @@ class Footer extends StatelessWidget {
     );
   }
 
+  Widget buildServerInteractiveText(String serverUri, BuildContext context) {
+    return createInteractiveText(
+      context: context,
+      text: serverUri,
+      onTap: () => _launchUrl(serverUri),
+      style: TextStyle(fontSize: 14, color: Colors.blue),
+    );
+  }
+
+  Widget buildLoginStatusInteractiveText(
+      String loginStatus, BuildContext context) {
+    return createInteractiveText(
+      context: context,
+      text: 'Login Status: ${webId == null ? "Not Logged In" : "Logged In"}',
+      onTap: () {
+        if (webId != null) {
+          handleLogout(context);
+        } else {
+          Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(builder: (context) => createSolidLogin(context)),
+          );
+        }
+      },
+      style: TextStyle(
+        fontSize: 14,
+        color: webId == null ? Colors.red : Colors.green,
+      ),
+    );
+  }
+
+  // TODO: build security key status interactive text
+
   Widget _buildNarrowLayout(String serverUri, String loginStatus,
-      Color loginStatusColor, String securityKeyStatus) {
+      Color loginStatusColor, String securityKeyStatus, BuildContext context) {
     return Container(
       color: Colors.grey[200],
       height: 90.0,
@@ -58,10 +103,9 @@ class Footer extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _buildTextRow('Server', serverUri),
+            buildServerInteractiveText(serverUri, context),
             const SizedBox(height: 2),
-            _buildTextRow('Login Status', loginStatus,
-                valueColor: loginStatusColor),
+            buildLoginStatusInteractiveText(loginStatus, context),
             const SizedBox(height: 2),
             _buildTextRow('Security Key', securityKeyStatus),
           ],
@@ -71,7 +115,7 @@ class Footer extends StatelessWidget {
   }
 
   Widget _buildMediumLayout(String serverUri, String loginStatus,
-      Color loginStatusColor, String securityKeyStatus) {
+      Color loginStatusColor, String securityKeyStatus, BuildContext context) {
     return Container(
       color: Colors.grey[200],
       height: 70.0,
@@ -80,15 +124,14 @@ class Footer extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            _buildTextRow('Server', serverUri),
+            buildServerInteractiveText(serverUri, context),
             const SizedBox(height: 4),
             SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _buildTextRow('Login Status', loginStatus,
-                      valueColor: loginStatusColor),
+                  buildLoginStatusInteractiveText(loginStatus, context),
                   const SizedBox(width: 16),
                   _buildTextRow('Security Key', securityKeyStatus),
                 ],
@@ -101,7 +144,7 @@ class Footer extends StatelessWidget {
   }
 
   Widget _buildWideLayout(String serverUri, String loginStatus,
-      Color loginStatusColor, String securityKeyStatus) {
+      Color loginStatusColor, String securityKeyStatus, BuildContext context) {
     return Container(
       color: Colors.grey[200],
       height: 50.0,
@@ -109,13 +152,12 @@ class Footer extends StatelessWidget {
       child: Row(
         children: [
           Expanded(
-            child: _buildTextRow('Server', serverUri),
+            child: buildServerInteractiveText(serverUri, context),
           ),
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _buildTextRow('Login Status', loginStatus,
-                  valueColor: loginStatusColor),
+              buildLoginStatusInteractiveText(loginStatus, context),
               const SizedBox(width: 16),
               _buildTextRow('Security Key', securityKeyStatus),
             ],
@@ -135,14 +177,14 @@ class Footer extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         if (constraints.maxWidth < 400) {
-          return _buildNarrowLayout(
-              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+          return _buildNarrowLayout(serverUri, loginStatus, loginStatusColor,
+              securityKeyStatus, context);
         } else if (constraints.maxWidth < 600) {
-          return _buildMediumLayout(
-              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+          return _buildMediumLayout(serverUri, loginStatus, loginStatusColor,
+              securityKeyStatus, context);
         } else {
-          return _buildWideLayout(
-              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+          return _buildWideLayout(serverUri, loginStatus, loginStatusColor,
+              securityKeyStatus, context);
         }
       },
     );

--- a/lib/widgets/footer.dart
+++ b/lib/widgets/footer.dart
@@ -42,7 +42,7 @@ class Footer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final serverUri = webId?.split('/profile')[0] ?? 'Not connected';
-    
+
     return LayoutBuilder(
       builder: (context, constraints) {
         // For very narrow screens (mobile), use three lines.
@@ -80,7 +80,7 @@ class Footer extends StatelessWidget {
             ),
           );
         }
-        
+
         // For medium screens, use two-line layout.
 
         if (constraints.maxWidth < 600) {
@@ -123,9 +123,9 @@ class Footer extends StatelessWidget {
             ),
           );
         }
-        
+
         // For wider screens, use single-line layout.
-        
+
         return Container(
           color: Colors.grey[200],
           height: 50.0,

--- a/lib/widgets/footer.dart
+++ b/lib/widgets/footer.dart
@@ -49,11 +49,14 @@ class Footer extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         if (constraints.maxWidth < 400) {
-          return _buildNarrowLayout(serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+          return _buildNarrowLayout(
+              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
         } else if (constraints.maxWidth < 600) {
-          return _buildMediumLayout(serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+          return _buildMediumLayout(
+              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
         } else {
-          return _buildWideLayout(serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+          return _buildWideLayout(
+              serverUri, loginStatus, loginStatusColor, securityKeyStatus);
         }
       },
     );
@@ -67,7 +70,8 @@ class Footer extends StatelessWidget {
     );
   }
 
-  Widget _buildNarrowLayout(String serverUri, String loginStatus, Color loginStatusColor, String securityKeyStatus) {
+  Widget _buildNarrowLayout(String serverUri, String loginStatus,
+      Color loginStatusColor, String securityKeyStatus) {
     return Container(
       color: Colors.grey[200],
       height: 90.0,
@@ -79,7 +83,8 @@ class Footer extends StatelessWidget {
           children: [
             _buildTextRow('Server', serverUri),
             const SizedBox(height: 2),
-            _buildTextRow('Login Status', loginStatus, valueColor: loginStatusColor),
+            _buildTextRow('Login Status', loginStatus,
+                valueColor: loginStatusColor),
             const SizedBox(height: 2),
             _buildTextRow('Security Key', securityKeyStatus),
           ],
@@ -88,7 +93,8 @@ class Footer extends StatelessWidget {
     );
   }
 
-  Widget _buildMediumLayout(String serverUri, String loginStatus, Color loginStatusColor, String securityKeyStatus) {
+  Widget _buildMediumLayout(String serverUri, String loginStatus,
+      Color loginStatusColor, String securityKeyStatus) {
     return Container(
       color: Colors.grey[200],
       height: 70.0,
@@ -104,7 +110,8 @@ class Footer extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _buildTextRow('Login Status', loginStatus, valueColor: loginStatusColor),
+                  _buildTextRow('Login Status', loginStatus,
+                      valueColor: loginStatusColor),
                   const SizedBox(width: 16),
                   _buildTextRow('Security Key', securityKeyStatus),
                 ],
@@ -116,7 +123,8 @@ class Footer extends StatelessWidget {
     );
   }
 
-  Widget _buildWideLayout(String serverUri, String loginStatus, Color loginStatusColor, String securityKeyStatus) {
+  Widget _buildWideLayout(String serverUri, String loginStatus,
+      Color loginStatusColor, String securityKeyStatus) {
     return Container(
       color: Colors.grey[200],
       height: 50.0,
@@ -129,7 +137,8 @@ class Footer extends StatelessWidget {
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _buildTextRow('Login Status', loginStatus, valueColor: loginStatusColor),
+              _buildTextRow('Login Status', loginStatus,
+                  valueColor: loginStatusColor),
               const SizedBox(width: 16),
               _buildTextRow('Security Key', securityKeyStatus),
             ],

--- a/lib/widgets/footer.dart
+++ b/lib/widgets/footer.dart
@@ -42,33 +42,124 @@ class Footer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final serverUri = webId?.split('/profile')[0] ?? 'Not connected';
+    
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // For very narrow screens (mobile), use three lines.
 
-    return Container(
-      color: Colors.grey[200],
-      child: Row(
-        children: [
-          Text(
-            'Server: $serverUri',
-            style: const TextStyle(fontSize: 14),
-            overflow: TextOverflow.ellipsis,
-          ),
-          const Spacer(),
-          Text(
-            'Login Status: ${webId == null ? "Not Logged In" : "Logged In"}',
-            style: TextStyle(
-              fontSize: 14,
-              color: webId == null ? Colors.red : Colors.green,
+        if (constraints.maxWidth < 400) {
+          return Container(
+            color: Colors.grey[200],
+            height: 90.0,
+            padding: const EdgeInsets.symmetric(horizontal: 12.0),
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Server: $serverUri',
+                    style: const TextStyle(fontSize: 14),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Login Status: ${webId == null ? "Not Logged In" : "Logged In"}',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: webId == null ? Colors.red : Colors.green,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Security Key: ${isKeySaved ? "Saved" : "Not Saved"}',
+                    style: const TextStyle(fontSize: 14),
+                  ),
+                ],
+              ),
             ),
-            overflow: TextOverflow.ellipsis,
+          );
+        }
+        
+        // For medium screens, use two-line layout.
+
+        if (constraints.maxWidth < 600) {
+          return Container(
+            color: Colors.grey[200],
+            height: 70.0,
+            padding: const EdgeInsets.symmetric(horizontal: 12.0),
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'Server: $serverUri',
+                    style: const TextStyle(fontSize: 14),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'Login Status: ${webId == null ? "Not Logged In" : "Logged In"}',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: webId == null ? Colors.red : Colors.green,
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Text(
+                          'Security Key: ${isKeySaved ? "Saved" : "Not Saved"}',
+                          style: const TextStyle(fontSize: 14),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+        
+        // For wider screens, use single-line layout.
+        
+        return Container(
+          color: Colors.grey[200],
+          height: 50.0,
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Server: $serverUri',
+                  style: const TextStyle(fontSize: 14),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Login Status: ${webId == null ? "Not Logged In" : "Logged In"}',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: webId == null ? Colors.red : Colors.green,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Text(
+                    'Security Key: ${isKeySaved ? "Saved" : "Not Saved"}',
+                    style: const TextStyle(fontSize: 14),
+                  ),
+                ],
+              ),
+            ],
           ),
-          const SizedBox(width: 8),
-          Text(
-            'Security Key: ${isKeySaved ? "Saved" : "Not Saved"}',
-            style: const TextStyle(fontSize: 14),
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/widgets/footer.dart
+++ b/lib/widgets/footer.dart
@@ -42,124 +42,100 @@ class Footer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final serverUri = webId?.split('/profile')[0] ?? 'Not connected';
+    final loginStatus = webId == null ? "Not Logged In" : "Logged In";
+    final loginStatusColor = webId == null ? Colors.red : Colors.green;
+    final securityKeyStatus = isKeySaved ? "Saved" : "Not Saved";
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        // For very narrow screens (mobile), use three lines.
-
         if (constraints.maxWidth < 400) {
-          return Container(
-            color: Colors.grey[200],
-            height: 90.0,
-            padding: const EdgeInsets.symmetric(horizontal: 12.0),
-            child: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Server: $serverUri',
-                    style: const TextStyle(fontSize: 14),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    'Login Status: ${webId == null ? "Not Logged In" : "Logged In"}',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: webId == null ? Colors.red : Colors.green,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    'Security Key: ${isKeySaved ? "Saved" : "Not Saved"}',
-                    style: const TextStyle(fontSize: 14),
-                  ),
-                ],
-              ),
-            ),
-          );
+          return _buildNarrowLayout(serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+        } else if (constraints.maxWidth < 600) {
+          return _buildMediumLayout(serverUri, loginStatus, loginStatusColor, securityKeyStatus);
+        } else {
+          return _buildWideLayout(serverUri, loginStatus, loginStatusColor, securityKeyStatus);
         }
+      },
+    );
+  }
 
-        // For medium screens, use two-line layout.
+  Widget _buildTextRow(String label, String value, {Color? valueColor}) {
+    return Text(
+      '$label: $value',
+      style: TextStyle(fontSize: 14, color: valueColor ?? Colors.black),
+      overflow: TextOverflow.ellipsis,
+    );
+  }
 
-        if (constraints.maxWidth < 600) {
-          return Container(
-            color: Colors.grey[200],
-            height: 70.0,
-            padding: const EdgeInsets.symmetric(horizontal: 12.0),
-            child: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    'Server: $serverUri',
-                    style: const TextStyle(fontSize: 14),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 4),
-                  SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          'Login Status: ${webId == null ? "Not Logged In" : "Logged In"}',
-                          style: TextStyle(
-                            fontSize: 14,
-                            color: webId == null ? Colors.red : Colors.green,
-                          ),
-                        ),
-                        const SizedBox(width: 16),
-                        Text(
-                          'Security Key: ${isKeySaved ? "Saved" : "Not Saved"}',
-                          style: const TextStyle(fontSize: 14),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          );
-        }
+  Widget _buildNarrowLayout(String serverUri, String loginStatus, Color loginStatusColor, String securityKeyStatus) {
+    return Container(
+      color: Colors.grey[200],
+      height: 90.0,
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildTextRow('Server', serverUri),
+            const SizedBox(height: 2),
+            _buildTextRow('Login Status', loginStatus, valueColor: loginStatusColor),
+            const SizedBox(height: 2),
+            _buildTextRow('Security Key', securityKeyStatus),
+          ],
+        ),
+      ),
+    );
+  }
 
-        // For wider screens, use single-line layout.
-
-        return Container(
-          color: Colors.grey[200],
-          height: 50.0,
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: Text(
-                  'Server: $serverUri',
-                  style: const TextStyle(fontSize: 14),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              Row(
+  Widget _buildMediumLayout(String serverUri, String loginStatus, Color loginStatusColor, String securityKeyStatus) {
+    return Container(
+      color: Colors.grey[200],
+      height: 70.0,
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            _buildTextRow('Server', serverUri),
+            const SizedBox(height: 4),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    'Login Status: ${webId == null ? "Not Logged In" : "Logged In"}',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: webId == null ? Colors.red : Colors.green,
-                    ),
-                  ),
+                  _buildTextRow('Login Status', loginStatus, valueColor: loginStatusColor),
                   const SizedBox(width: 16),
-                  Text(
-                    'Security Key: ${isKeySaved ? "Saved" : "Not Saved"}',
-                    style: const TextStyle(fontSize: 14),
-                  ),
+                  _buildTextRow('Security Key', securityKeyStatus),
                 ],
               ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWideLayout(String serverUri, String loginStatus, Color loginStatusColor, String securityKeyStatus) {
+    return Container(
+      color: Colors.grey[200],
+      height: 50.0,
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      child: Row(
+        children: [
+          Expanded(
+            child: _buildTextRow('Server', serverUri),
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildTextRow('Login Status', loginStatus, valueColor: loginStatusColor),
+              const SizedBox(width: 16),
+              _buildTextRow('Security Key', securityKeyStatus),
             ],
           ),
-        );
-      },
+        ],
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   universal_io: ^2.2.2
   window_manager: ^0.4.3
   build_runner: ^2.4.14
+  url_launcher: ^6.3.1
 
 dev_dependencies:
 


### PR DESCRIPTION
## Pull Request Details
Link to associated issue: https://github.com/anusii/healthpod/issues/31

- Tapping server text takes user to url in external browser
- Tapping login status text: a) if logged in, takes user to logout confirmation dialog b) if logged out, takes user to login screen
- TODO: make security key status text tappable

# Checklist
Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (make prep or flutter analyze lib)
- [x] Tested on at least one device
  - [x] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another) - 1 for now