### PR TITLE
add upload local survey data functionality

### DIFF
--- a/lib/features/file/browser.dart
+++ b/lib/features/file/browser.dart
@@ -90,7 +90,7 @@ class FileBrowserState extends State<FileBrowser> {
 
     // Notify parent about directory change.
 
-    widget.onDirectoryChanged?.call(currentPath);
+    widget.onDirectoryChanged.call(currentPath);
   }
 
   // Users can navigate up by removing the last directory from the path history.
@@ -103,7 +103,7 @@ class FileBrowserState extends State<FileBrowser> {
 
         // Notify parent about directory change.
 
-        widget.onDirectoryChanged?.call(currentPath);
+        widget.onDirectoryChanged.call(currentPath);
       });
       await refreshFiles();
     }

--- a/lib/features/file/browser.dart
+++ b/lib/features/file/browser.dart
@@ -43,6 +43,7 @@ class FileBrowser extends StatefulWidget {
   final Function(String, String) onFileSelected;
   final Function(String, String) onFileDownload;
   final Function(String, String) onFileDelete;
+  final Function(String)? onDirectoryChanged;
   final GlobalKey<FileBrowserState> browserKey;
 
   const FileBrowser({
@@ -51,6 +52,7 @@ class FileBrowser extends StatefulWidget {
     required this.onFileDownload,
     required this.onFileDelete,
     required this.browserKey,
+    this.onDirectoryChanged,
   });
 
   @override
@@ -85,6 +87,10 @@ class FileBrowserState extends State<FileBrowser> {
       pathHistory.add(currentPath);
     });
     await refreshFiles();
+
+    // Notify parent about directory change.
+
+    widget.onDirectoryChanged?.call(currentPath);
   }
 
   // Users can navigate up by removing the last directory from the path history.
@@ -94,6 +100,10 @@ class FileBrowserState extends State<FileBrowser> {
       pathHistory.removeLast();
       setState(() {
         currentPath = pathHistory.last;
+
+        // Notify parent about directory change.
+
+        widget.onDirectoryChanged?.call(currentPath);
       });
       await refreshFiles();
     }

--- a/lib/features/file/browser.dart
+++ b/lib/features/file/browser.dart
@@ -43,7 +43,7 @@ class FileBrowser extends StatefulWidget {
   final Function(String, String) onFileSelected;
   final Function(String, String) onFileDownload;
   final Function(String, String) onFileDelete;
-  final Function(String)? onDirectoryChanged;
+  final Function(String) onDirectoryChanged;
   final GlobalKey<FileBrowserState> browserKey;
 
   const FileBrowser({
@@ -52,7 +52,7 @@ class FileBrowser extends StatefulWidget {
     required this.onFileDownload,
     required this.onFileDelete,
     required this.browserKey,
-    this.onDirectoryChanged,
+    required this.onDirectoryChanged,
   });
 
   @override


### PR DESCRIPTION
## Pull Request Details

- The main change here is adding functionality to upload to a subfolder. Previously, all uploaded files were added to the root `healthpod/data` directory.
- Now upon navigating to `healthpod/data/bp` in file browser, users can upload any file to the `bp` folder e.g. local health survey data.

Link to associated issue: https://github.com/anusii/healthpod/issues/52

Merging into https://github.com/anusii/healthpod/pull/66 as a related PR

# Checklist
Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (make prep or flutter analyze lib)
- [x] Tested on at least one device
  - [x] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another) - 1 for now